### PR TITLE
feat: 'internal-directory' Rule 추가

### DIFF
--- a/src/eslint/rules/restrict-imports.ts
+++ b/src/eslint/rules/restrict-imports.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import {
   DEFAULT_RESTRICTIONS,
   type ModuleRestriction,
+  rules,
   validateImport,
 } from "../../shared";
 
@@ -30,12 +31,7 @@ export const restrictImportsRule: Rule.RuleModule = {
                 pattern: { type: "string" },
                 rule: {
                   type: "string",
-                  enum: [
-                    "same-directory",
-                    "shared-module",
-                    "private-module",
-                    "custom",
-                  ],
+                  enum: rules,
                 },
                 message: { type: "string" },
                 allowedImporters: {

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -1,6 +1,21 @@
+export enum Rule {
+  SAME_DIRECTORY = "same-directory",
+  SHARED_MODULE = "shared-module",
+  PRIVATE_MODULE = "private-module",
+  INTERNAL_DIRECTORY = "internal-directory",
+  CUSTOM = "custom",
+}
+
+export const rules = Object.values(Rule);
+
 export interface ModuleRestriction {
   pattern: string;
-  rule: "same-directory" | "shared-module" | "private-module" | "custom";
+  rule:
+    | Rule.SAME_DIRECTORY
+    | Rule.SHARED_MODULE
+    | Rule.PRIVATE_MODULE
+    | Rule.INTERNAL_DIRECTORY
+    | Rule.CUSTOM;
   message?: string;
   allowedImporters?: string[];
 }
@@ -8,19 +23,25 @@ export interface ModuleRestriction {
 export const DEFAULT_RESTRICTIONS: ModuleRestriction[] = [
   {
     pattern: "**/*.internal.*",
-    rule: "same-directory",
+    rule: Rule.SAME_DIRECTORY,
     message: "Internal modules can only be imported within the same directory",
   },
   {
     pattern: "**/*.shared.*",
-    rule: "shared-module",
+    rule: Rule.SHARED_MODULE,
     message:
       "Shared modules can only be imported by files with matching parent prefix",
   },
   {
     pattern: "**/*.private.*",
-    rule: "private-module",
+    rule: Rule.PRIVATE_MODULE,
     message:
       "Private modules can only be imported by files with same parent name",
+  },
+  {
+    pattern: "**/_*/**/*",
+    rule: Rule.INTERNAL_DIRECTORY,
+    message:
+      "Files in underscore-prefixed directories can only be imported from the same level or within the directory",
   },
 ];

--- a/src/shared/matcher.ts
+++ b/src/shared/matcher.ts
@@ -31,6 +31,36 @@ export function isImportAllowed(
       const importerPrefix = importerBasename.split(".")[0];
       return importedPrefix === importerPrefix;
 
+    case "internal-directory":
+      // _로 시작하는 폴더 내부의 파일인지 확인
+      const importedPathParts = importedPath.split(path.sep);
+      const underscoreDirIndex = importedPathParts.findIndex(
+        (part) => part.startsWith("_") && part.length > 1
+      );
+
+      if (underscoreDirIndex === -1) {
+        // _로 시작하는 폴더가 아니면 제한 없음
+        return true;
+      }
+
+      // underscore 디렉토리 경로 추출
+      const underscoreDirPath = importedPathParts
+        .slice(0, underscoreDirIndex + 1)
+        .join(path.sep);
+      const importerPathParts = importerPath.split(path.sep);
+
+      // 같은 레벨에서 import하는 경우 (underscore 디렉토리와 같은 부모 디렉토리)
+      const sameLevelImport =
+        importerPathParts.slice(0, underscoreDirIndex).join(path.sep) ===
+        importedPathParts.slice(0, underscoreDirIndex).join(path.sep);
+
+      // underscore 디렉토리 내부에서 import하는 경우
+      const internalImport = importerPath.startsWith(
+        underscoreDirPath + path.sep
+      );
+
+      return sameLevelImport || internalImport;
+
     case "custom":
       return (
         restriction.allowedImporters?.some((pattern) =>


### PR DESCRIPTION
- _로 시작하는 폴더 내부 모듈은 같은 레벨에서만 import 가능